### PR TITLE
Add Flowbite header/footer and Livewire search

### DIFF
--- a/app/Http/Livewire/SearchForm.php
+++ b/app/Http/Livewire/SearchForm.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use Livewire\Component;
+
+class SearchForm extends Component
+{
+    public string $query = '';
+    public string $routeName = '';
+    public string $queryParam = 'q';
+
+    public function mount(string $routeName, string $queryParam = 'q')
+    {
+        $this->routeName = $routeName;
+        $this->queryParam = $queryParam;
+        $this->query = request()->query($this->queryParam, '');
+    }
+
+    public function search()
+    {
+        return redirect()->route($this->routeName, [$this->queryParam => $this->query]);
+    }
+
+    public function render()
+    {
+        return view('livewire.search-form');
+    }
+}
+

--- a/app/Http/Livewire/SearchForm.php
+++ b/app/Http/Livewire/SearchForm.php
@@ -22,6 +22,12 @@ class SearchForm extends Component
         return redirect()->route($this->routeName, [$this->queryParam => $this->query]);
     }
 
+    public function resetSearch()
+    {
+        $this->query = '';
+        return redirect()->route($this->routeName);
+    }
+
     public function render()
     {
         return view('livewire.search-form');

--- a/resources/views/appointments/create.blade.php
+++ b/resources/views/appointments/create.blade.php
@@ -4,12 +4,16 @@
 
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Add New Appointment') }}
-        </h2>
+        <div class="flex items-center space-x-2">
+            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M6.75 2.25A.75.75 0 017.5 3v1.5h9V3a.75.75 0 011.5 0V4.5h.75A2.25 2.25 0 0121 6.75v11.25A2.25 2.25 0 0118.75 20.25H5.25A2.25 2.25 0 013 18V6.75A2.25 2.25 0 015.25 4.5H6V3a.75.75 0 01.75-.75zM20.25 9.75H3.75v8.25c0 .621.504 1.125 1.125 1.125h15.75c.621 0 1.125-.504 1.125-1.125V9.75z" fill="currentColor"/>
+            </svg>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Add New Appointment') }}</h2>
+        </div>
+        <x-breadcrumb current="Add Appointment" />
     </x-slot>
 
-    <div class="py-12">
+    <div class="py-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="relative overflow-x-auto shadow-md sm:rounded-lg px-4 py-4">

--- a/resources/views/appointments/edit.blade.php
+++ b/resources/views/appointments/edit.blade.php
@@ -5,12 +5,16 @@
 
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Edit Appointment') }}
-        </h2>
+        <div class="flex items-center space-x-2">
+            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M6.75 2.25A.75.75 0 017.5 3v1.5h9V3a.75.75 0 011.5 0V4.5h.75A2.25 2.25 0 0121 6.75v11.25A2.25 2.25 0 0118.75 20.25H5.25A2.25 2.25 0 013 18V6.75A2.25 2.25 0 015.25 4.5H6V3a.75.75 0 01.75-.75zM20.25 9.75H3.75v8.25c0 .621.504 1.125 1.125 1.125h15.75c.621 0 1.125-.504 1.125-1.125V9.75z" fill="currentColor"/>
+            </svg>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Edit Appointment') }}</h2>
+        </div>
+        <x-breadcrumb current="Edit Appointment" />
     </x-slot>
 
-    <div class="py-12">
+    <div class="py-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="relative overflow-x-auto shadow-md sm:rounded-lg px-4 py-4">

--- a/resources/views/appointments/index.blade.php
+++ b/resources/views/appointments/index.blade.php
@@ -22,6 +22,7 @@
                     </div>
                     @endcan
                     <div class="m-3 flex items-center space-x-4">
+                        <livewire:search-form route-name="appointments.index" query-param="pname" placeholder="Search patient" />
                         <button id="advanceSearchBtn" class="mt-4 px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:bg-blue-600">Advance Search</button>
                     </div>
                     <div id="searchContainer" class="ml-4 hidden">

--- a/resources/views/appointments/index.blade.php
+++ b/resources/views/appointments/index.blade.php
@@ -20,9 +20,9 @@
                     @endif
 
                     @can('manage patients')
-                    <div class="float-right m-3">
-                        <x-link href="{{ route('appointments.create') }}" class="m-4">Book Appointment</x-link>
-                        <x-link href="{{ route('patients.create') }}" class="m-4">Add new Patient</x-link>
+                    <div class="float-right m-3 space-x-2">
+                        <x-button type="button" onclick="window.location='{{ route('appointments.create') }}'">Book Appointment</x-button>
+                        <x-button type="button" onclick="window.location='{{ route('patients.create') }}'">Add new Patient</x-button>
                     </div>
                     @endcan
                     <div class="m-3 flex items-center space-x-4">

--- a/resources/views/appointments/index.blade.php
+++ b/resources/views/appointments/index.blade.php
@@ -23,7 +23,7 @@
                     @endcan
                     <div class="m-3 flex items-center space-x-4">
                         <livewire:search-form route-name="appointments.index" query-param="pname" placeholder="Search patient" />
-                        <button id="advanceSearchBtn" class="mt-4 px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:bg-blue-600">Advance Search</button>
+                        <button id="advanceSearchBtn" class="h-10 px-4 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:bg-blue-600">Advance Search</button>
                     </div>
                     <div id="searchContainer" class="ml-4 hidden">
                         <form action="{{ route('appointments.index') }}" method="GET" class="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/resources/views/appointments/index.blade.php
+++ b/resources/views/appointments/index.blade.php
@@ -1,11 +1,15 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Appointments') }}
-        </h2>
+        <div class="flex items-center space-x-2">
+            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M6.75 2.25A.75.75 0 017.5 3v1.5h9V3a.75.75 0 011.5 0V4.5h.75A2.25 2.25 0 0121 6.75v11.25A2.25 2.25 0 0118.75 20.25H5.25A2.25 2.25 0 013 18V6.75A2.25 2.25 0 015.25 4.5H6V3a.75.75 0 01.75-.75zM20.25 9.75H3.75v8.25c0 .621.504 1.125 1.125 1.125h15.75c.621 0 1.125-.504 1.125-1.125V9.75z" fill="currentColor"/>
+            </svg>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Appointments') }}</h2>
+        </div>
+        <x-breadcrumb current="Appointments" />
     </x-slot>
 
-    <div class="py-12">
+    <div class="py-6">
         <div class="max-w-8xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="relative overflow-x-auto shadow-md sm:rounded-lg">
@@ -23,7 +27,7 @@
                     @endcan
                     <div class="m-3 flex items-center space-x-4">
                         <livewire:search-form route-name="appointments.index" query-param="pname" placeholder="Search patient" />
-                        <button id="advanceSearchBtn" class="h-10 px-4 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:bg-blue-600">Advance Search</button>
+                        <x-button type="button" id="advanceSearchBtn">Advance Search</x-button>
                     </div>
                     <div id="searchContainer" class="ml-4 hidden">
                         <form action="{{ route('appointments.index') }}" method="GET" class="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -96,8 +100,8 @@
                                 <input type="text" id="aend_date" name="aend_date" class="mt-1 w-full datepicker rounded-md shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" value="{{ $aendDate }}" placeholder="Select End Date">
                             </div>
                             <div class="md:col-span-3 flex items-center space-x-2 mt-4">
-                                <button type="submit" class="px-4 py-2 text-white bg-blue-600 hover:bg-blue-700 rounded-md">Search</button>
-                                <a href="{{ route('appointments.index') }}" class="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300">Reset</a>
+                                <x-button type="submit">Search</x-button>
+                                <x-secondary-button type="button" onclick="window.location='{{ route('appointments.index') }}'">Reset</x-secondary-button>
                             </div>
                         </form>
                     </div>

--- a/resources/views/components/breadcrumb.blade.php
+++ b/resources/views/components/breadcrumb.blade.php
@@ -1,0 +1,7 @@
+<nav class="text-sm text-gray-500 mb-2" aria-label="Breadcrumb">
+    <ol class="list-reset flex items-center space-x-2">
+        <li><a href="{{ route('dashboard') }}" class="text-blue-600 hover:underline">Dashboard</a></li>
+        <li>/</li>
+        <li class="text-gray-700">{{ $current }}</li>
+    </ol>
+</nav>

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,0 +1,4 @@
+<footer class="bg-white border-t border-gray-200 text-center p-4 mt-8">
+    <span class="text-sm text-gray-500">© {{ date('Y') }} {{ config('app.name', 'TCC') }}. All Rights Reserved.</span>
+</footer>
+

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,7 +1,8 @@
 <header class="bg-white border-b border-gray-200 fixed w-full z-20 top-0 left-0 md:pl-64">
     <div class="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
-        <a href="{{ route('dashboard') }}" class="flex items-center">
-            <x-application-mark class="h-8 w-8 mr-3" />
+        <a href="{{ route('dashboard') }}" class="flex items-center space-x-2">
+            <x-application-mark class="h-8 w-8" />
+            <x-application-mark class="h-8 w-8" />
             <span class="self-center text-2xl font-semibold whitespace-nowrap">{{ config('app.name', 'TCC') }}</span>
         </a>
         <button data-drawer-target="sidebar" data-drawer-toggle="sidebar" aria-controls="sidebar" type="button"

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,4 +1,4 @@
-<header class="bg-white border-b border-gray-200 fixed w-full z-20 top-0 left-0">
+<header class="bg-white border-b border-gray-200 fixed w-full z-20 top-0 left-0 md:pl-64">
     <div class="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
         <a href="{{ route('dashboard') }}" class="flex items-center">
             <x-application-mark class="h-8 w-8 mr-3" />

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,6 +1,6 @@
 <header class="bg-white border-b border-gray-200 fixed w-full z-20 top-0 left-0 md:pl-64">
-    <div class="max-w-screen-xl mx-auto flex items-center justify-between p-4">
-        <div class="flex items-center space-x-2">
+    <div class="max-w-screen-xl mx-auto flex items-center justify-between p-4 min-h-16">
+        <div class="space-y-1">
             {{ $slot }}
         </div>
         <button data-drawer-target="sidebar" data-drawer-toggle="sidebar" aria-controls="sidebar" type="button"

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,10 +1,8 @@
 <header class="bg-white border-b border-gray-200 fixed w-full z-20 top-0 left-0 md:pl-64">
-    <div class="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
-        <a href="{{ route('dashboard') }}" class="flex items-center space-x-2">
-            <x-application-mark class="h-8 w-8" />
-            <x-application-mark class="h-8 w-8" />
-            <span class="self-center text-2xl font-semibold whitespace-nowrap">{{ config('app.name', 'TCC') }}</span>
-        </a>
+    <div class="max-w-screen-xl mx-auto flex items-center justify-between p-4">
+        <div class="flex items-center space-x-2">
+            {{ $slot }}
+        </div>
         <button data-drawer-target="sidebar" data-drawer-toggle="sidebar" aria-controls="sidebar" type="button"
             class="inline-flex items-center p-2 ml-3 text-sm text-gray-500 rounded-lg md:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200">
             <span class="sr-only">Open sidebar</span>

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,0 +1,17 @@
+<header class="bg-white border-b border-gray-200 fixed w-full z-20 top-0 left-0">
+    <div class="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
+        <a href="{{ route('dashboard') }}" class="flex items-center">
+            <x-application-mark class="h-8 w-8 mr-3" />
+            <span class="self-center text-2xl font-semibold whitespace-nowrap">{{ config('app.name', 'TCC') }}</span>
+        </a>
+        <button data-drawer-target="sidebar" data-drawer-toggle="sidebar" aria-controls="sidebar" type="button"
+            class="inline-flex items-center p-2 ml-3 text-sm text-gray-500 rounded-lg md:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200">
+            <span class="sr-only">Open sidebar</span>
+            <svg class="w-6 h-6" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                <path clip-rule="evenodd" fill-rule="evenodd"
+                    d="M2 4.75A.75.75 0 012.75 4h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 4.75zm0 10.5a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75zM2 10a.75.75 0 01.75-.75h14.5a.75.75 0 010 1.5H2.75A.75.75 0 012 10z" />
+            </svg>
+        </button>
+    </div>
+</header>
+

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,26 +1,28 @@
 <x-app-layout>
     <x-slot name="header">
-        <div class="flex items-center justify-between">
-            <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-                {{ __('Dashboard') }}
-            </h2>
-            <div class="space-x-2">
-                <x-button type="button" onclick="window.location='{{ route('patients.create') }}'">{{ __('Add Patient') }}</x-button>
-                <x-button type="button" onclick="window.location='{{ route('appointments.create') }}'">{{ __('Book Appointment') }}</x-button>
-            </div>
-        </div>
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Dashboard') }}
+        </h2>
     </x-slot>
 
     <div class="py-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
-                <div class="p-6 bg-blue-600 text-white rounded-t-lg text-center">
-                    <div class="text-2xl font-bold">Performer of the Week</div>
-                    <div class="mt-4">
-                        <div class="text-xl font-semibold">{{$userDetails->name ?? 'No user data found'}}</div>
-                        <div>Total Leads: {{$totalAppointmentsUser ?? 0}}</div>
-                        <div>Appointments: {{$maxVisitedUser->visited_count ?? 0}}</div>
-                        <div>Conversion Rate: {{ number_format($visitedRatioUser,2) ?? 0}}%</div>
+                <div class="p-6 bg-blue-600 text-white rounded-t-lg">
+                    <div class="flex flex-col lg:flex-row lg:items-center justify-between">
+                        <div class="text-center lg:text-left">
+                            <div class="text-2xl font-bold">Performer of the Week</div>
+                            <div class="mt-2">
+                                <div class="text-xl font-semibold">{{$userDetails->name ?? 'No user data found'}}</div>
+                                <div>Total Leads: {{$totalAppointmentsUser ?? 0}}</div>
+                                <div>Appointments: {{$maxVisitedUser->visited_count ?? 0}}</div>
+                                <div>Conversion Rate: {{ number_format($visitedRatioUser,2) ?? 0}}%</div>
+                            </div>
+                        </div>
+                        <div class="mt-4 lg:mt-0 flex items-center justify-center space-x-2">
+                            <x-button type="button" onclick="window.location='{{ route('patients.create') }}'">{{ __('Add Patient') }}</x-button>
+                            <x-button type="button" onclick="window.location='{{ route('appointments.create') }}'">{{ __('Book Appointment') }}</x-button>
+                        </div>
                     </div>
                 </div>
                 @if (auth()->user()->hasRole('Administrator') || auth()->user()->hasRole('Manager'))

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,25 +1,32 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Dashboard') }}
-        </h2>
+        <div class="flex items-center space-x-2">
+            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 2.25L3 9.75V21a.75.75 0 00.75.75H9v-6h6v6h5.25A.75.75 0 0021 21V9.75L12 2.25z" fill="currentColor" />
+            </svg>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Dashboard') }}</h2>
+        </div>
+        <x-breadcrumb current="Dashboard" />
     </x-slot>
 
     <div class="py-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
-                <div class="p-6 bg-blue-600 text-white rounded-t-lg">
-                    <div class="flex flex-col lg:flex-row lg:items-center justify-between">
-                        <div class="text-center lg:text-left">
-                            <div class="text-2xl font-bold">Performer of the Week</div>
-                            <div class="mt-2">
-                                <div class="text-xl font-semibold">{{$userDetails->name ?? 'No user data found'}}</div>
-                                <div>Total Leads: {{$totalAppointmentsUser ?? 0}}</div>
-                                <div>Appointments: {{$maxVisitedUser->visited_count ?? 0}}</div>
-                                <div>Conversion Rate: {{ number_format($visitedRatioUser,2) ?? 0}}%</div>
+                <div class="p-6">
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div class="flex items-center p-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-lg space-x-4">
+                            <svg class="w-10 h-10 text-yellow-300" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M11.049 2.927a1 1 0 011.902 0l2.11 6.49h6.823a1 1 0 01.588 1.81l-5.52 4.013 2.11 6.49a1 1 0 01-1.538 1.118L12 17.77l-5.524 4.078a1 1 0 01-1.538-1.118l2.11-6.49-5.522-4.013a1 1 0 01.588-1.81h6.824l2.11-6.49z" />
+                            </svg>
+                            <div>
+                                <div class="text-sm uppercase font-semibold tracking-wider">Performer of the Week</div>
+                                <div class="text-xl font-bold">{{$userDetails->name ?? 'No user data found'}}</div>
+                                <div class="text-sm mt-1">Total Leads: {{$totalAppointmentsUser ?? 0}}</div>
+                                <div class="text-sm">Appointments: {{$maxVisitedUser->visited_count ?? 0}}</div>
+                                <div class="text-sm">Conversion Rate: {{ number_format($visitedRatioUser,2) ?? 0}}%</div>
                             </div>
                         </div>
-                        <div class="mt-4 lg:mt-0 flex items-center justify-center space-x-2">
+                        <div class="flex items-center justify-center p-4 bg-gray-50 rounded-lg space-x-2">
                             <x-button type="button" onclick="window.location='{{ route('patients.create') }}'">{{ __('Add Patient') }}</x-button>
                             <x-button type="button" onclick="window.location='{{ route('appointments.create') }}'">{{ __('Book Appointment') }}</x-button>
                         </div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -11,7 +11,7 @@
         </div>
     </x-slot>
 
-    <div class="py-12">
+    <div class="py-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="p-6 bg-blue-600 text-white rounded-t-lg text-center">

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -26,7 +26,7 @@
                                 <div class="text-sm">Conversion Rate: {{ number_format($visitedRatioUser,2) ?? 0}}%</div>
                             </div>
                         </div>
-                        <div class="flex items-center justify-center p-4 bg-gray-50 rounded-lg space-x-2">
+                        <div class="flex items-center justify-center p-4 bg-gradient-to-r from-blue-500 to-indigo-600 text-white rounded-lg space-x-2">
                             <x-button type="button" onclick="window.location='{{ route('patients.create') }}'">{{ __('Add Patient') }}</x-button>
                             <x-button type="button" onclick="window.location='{{ route('appointments.create') }}'">{{ __('Book Appointment') }}</x-button>
                         </div>

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,11 +1,15 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Users') }}
-        </h2>
+        <div class="flex items-center space-x-2">
+            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 12c2.485 0 4.5-2.015 4.5-4.5S14.485 3 12 3 7.5 5.015 7.5 7.5 9.515 12 12 12zM3 21a9 9 0 0118 0H3z" fill="currentColor"/>
+            </svg>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Forbidden') }}</h2>
+        </div>
+        <x-breadcrumb current="Forbidden" />
     </x-slot>
 
-    <div class="py-12">
+    <div class="py-6">
         <div class="max-w-8xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="relative overflow-x-auto shadow-md sm:rounded-lg p-6">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -23,8 +23,9 @@
         <!-- Styles -->
         @livewireStyles
     </head>
-    <body class="font-sans antialiased bg-gray-100">
+    <body class="font-sans antialiased bg-gray-100 pt-16">
         <x-banner />
+        <x-header />
 
         <div class="min-h-screen flex">
             @livewire('navigation-menu')
@@ -41,6 +42,7 @@
                 <main class="p-4">
                     {{ $slot }}
                 </main>
+                <x-footer />
             </div>
         </div>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -34,9 +34,9 @@
         <div class="min-h-screen flex">
             @livewire('navigation-menu')
 
-            <div class="flex-1 md:ml-64">
+            <div class="flex-1 md:ml-64 flex flex-col min-h-screen">
 
-                <main class="p-4">
+                <main class="p-4 flex-grow">
                     {{ $slot }}
                 </main>
                 <x-footer />

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -25,19 +25,16 @@
     </head>
     <body class="font-sans antialiased bg-gray-100 pt-16">
         <x-banner />
-        <x-header />
+        <x-header>
+            @isset($header)
+                {{ $header }}
+            @endisset
+        </x-header>
 
         <div class="min-h-screen flex">
             @livewire('navigation-menu')
 
             <div class="flex-1 md:ml-64">
-                @if (isset($header))
-                    <header class="bg-white shadow">
-                        <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-                            {{ $header }}
-                        </div>
-                    </header>
-                @endif
 
                 <main class="p-4">
                     {{ $slot }}

--- a/resources/views/livewire/add-activity-log.blade.php
+++ b/resources/views/livewire/add-activity-log.blade.php
@@ -1,7 +1,5 @@
 <div class="mb-4">
-    <button wire:click="openModal" class="bg-black text-white px-2 py-1 rounded hover:bg-gray-700 focus:outline-none focus:ring focus:ring-gray-300">
-        Add Comment
-    </button>
+    <x-button type="button" wire:click="openModal">Add Comment</x-button>
 
      @if ($isOpen)
         <div class="fixed inset-0 z-10 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true" style="display: block;">
@@ -25,9 +23,7 @@
                                     <textarea wire:model="activityDescription" class="form-input mt-1 block w-full" id="activityDescription" name="activityDescription" rows="4"></textarea>
                                 </div>
                                 <div class="mt-4 flex justify-between items-center">
-                                    <button type="submit" class="bg-black text-white px-2 py-1 rounded hover:bg-gray-700 focus:outline-none focus:ring focus:ring-gray-300">
-                                        Save
-                                    </button>
+                                    <x-button type="submit">Save</x-button>
                                 </div>
                             </form>
                         </div>

--- a/resources/views/livewire/search-form.blade.php
+++ b/resources/views/livewire/search-form.blade.php
@@ -1,0 +1,5 @@
+<form wire:submit.prevent="search" class="flex space-x-2">
+    <input type="search" wire:model.defer="query" :placeholder="$attributes->get('placeholder')" class="w-full rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+    <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600">Search</button>
+</form>
+

--- a/resources/views/livewire/search-form.blade.php
+++ b/resources/views/livewire/search-form.blade.php
@@ -1,6 +1,6 @@
 <form wire:submit.prevent="search" class="flex space-x-2">
     <input type="search" wire:model.defer="query" :placeholder="$attributes->get('placeholder')" class="w-full h-10 rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
-    <button type="submit" class="h-10 px-4 bg-blue-500 text-white rounded-md hover:bg-blue-600">Search</button>
-    <button type="button" wire:click="resetSearch" class="h-10 px-4 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300">Reset</button>
+    <x-button type="submit">Search</x-button>
+    <x-secondary-button type="button" wire:click="resetSearch">Reset</x-secondary-button>
 </form>
 

--- a/resources/views/livewire/search-form.blade.php
+++ b/resources/views/livewire/search-form.blade.php
@@ -1,5 +1,6 @@
 <form wire:submit.prevent="search" class="flex space-x-2">
-    <input type="search" wire:model.defer="query" :placeholder="$attributes->get('placeholder')" class="w-full rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
-    <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600">Search</button>
+    <input type="search" wire:model.defer="query" :placeholder="$attributes->get('placeholder')" class="w-full h-10 rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
+    <button type="submit" class="h-10 px-4 bg-blue-500 text-white rounded-md hover:bg-blue-600">Search</button>
+    <button type="button" wire:click="resetSearch" class="h-10 px-4 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300">Reset</button>
 </form>
 

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -1,43 +1,7 @@
-<nav x-data="{ open: false }">
-    <!-- Mobile Navigation -->
-    <div class="bg-white border-b border-gray-200 shadow md:hidden">
-        <div class="flex justify-between h-16 px-4">
-            <a href="{{ route('dashboard') }}" class="flex items-center">
-                <x-application-mark class="block h-9 w-auto" />
-            </a>
-            <button @click="open = ! open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none transition">
-                <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
-                    <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                    <path :class="{'hidden': ! open, 'inline-flex': open }" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-            </button>
-        </div>
-        <div x-show="open" class="pb-3 space-y-1">
-            <x-responsive-nav-link href="{{ route('dashboard') }}" :active="request()->routeIs('dashboard')">
-                {{ __('Dashboard') }}
-            </x-responsive-nav-link>
-            <x-responsive-nav-link href="{{ route('appointments.index') }}" :active="request()->routeIs('appointments.*')">
-                {{ __('Appointments') }}
-            </x-responsive-nav-link>
-            @role('Administrator')
-            <x-responsive-nav-link href="{{ route('patients.index') }}" :active="request()->routeIs('patients.*')">
-                {{ __('Patients') }}
-            </x-responsive-nav-link>
-            <x-responsive-nav-link href="{{ route('users.index') }}" :active="request()->routeIs('users.*')">
-                {{ __('Users') }}
-            </x-responsive-nav-link>
-            @endrole
-            <form method="POST" action="{{ route('logout') }}" x-data>
-                @csrf
-                <x-responsive-nav-link href="{{ route('logout') }}" @click.prevent="$root.submit();">
-                    {{ __('Log Out') }}
-                </x-responsive-nav-link>
-            </form>
-        </div>
-    </div>
+<nav>
 
     <!-- Desktop Sidebar -->
-    <aside id="sidebar" class="fixed top-16 left-0 z-40 w-64 h-screen transition-transform -translate-x-full md:translate-x-0" aria-label="Sidebar">
+    <aside id="sidebar" class="fixed top-16 left-0 z-40 w-64 h-screen transition-transform -translate-x-full md:translate-x-0 md:fixed md:inset-y-0 md:flex md:flex-col" aria-label="Sidebar">
     <div class="h-full px-3 py-4 overflow-y-auto bg-white border-r border-gray-200">
         <div class="h-16 flex items-center justify-center space-x-2 border-b">
             <a href="{{ route('dashboard') }}" class="flex items-center space-x-2">

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -37,14 +37,15 @@
     </div>
 
     <!-- Desktop Sidebar -->
-    <div class="hidden md:fixed md:inset-y-0 md:flex md:flex-col md:w-64 md:h-screen md:border-r md:border-gray-200 md:bg-white">
+    <aside id="sidebar" class="fixed top-16 left-0 z-40 w-64 h-screen transition-transform -translate-x-full md:translate-x-0" aria-label="Sidebar">
+    <div class="h-full px-3 py-4 overflow-y-auto bg-white border-r border-gray-200">
         <div class="h-16 flex items-center justify-center space-x-2 border-b">
             <a href="{{ route('dashboard') }}" class="flex items-center space-x-2">
                 <x-application-logo class="block h-10 w-auto" />
                 <span class="text-lg font-semibold">{{ config('app.name', 'TCC') }}</span>
             </a>
         </div>
-        <div class="flex-1 overflow-y-auto px-4 py-6 space-y-1">
+        <div class="flex-1 overflow-y-auto px-4 py-6 space-y-2">
             <x-nav-link href="{{ route('dashboard') }}" :active="request()->routeIs('dashboard')">
                 <svg class="w-5 h-5 mr-2" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M12 2.25L3 9.75V21a.75.75 0 00.75.75H9v-6h6v6h5.25A.75.75 0 0021 21V9.75L12 2.25z" fill="currentColor"/>
@@ -94,4 +95,5 @@
             </form>
         </div>
     </div>
+    </aside>
 </nav>

--- a/resources/views/patients/create.blade.php
+++ b/resources/views/patients/create.blade.php
@@ -1,12 +1,16 @@
 @props(['birtDateOptions' => "{dateFormat:'Y-m-d', enableTime:false, defaultDate: 'today', maxDate: 'today'}"])
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Add New Patient') }}
-        </h2>
+        <div class="flex items-center space-x-2">
+            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 12c2.485 0 4.5-2.015 4.5-4.5S14.485 3 12 3 7.5 5.015 7.5 7.5 9.515 12 12 12zM3 21a9 9 0 0118 0H3z" fill="currentColor"/>
+            </svg>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Add New Patient') }}</h2>
+        </div>
+        <x-breadcrumb current="Add Patient" />
     </x-slot>
 
-    <div class="py-12">
+    <div class="py-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="relative overflow-x-auto shadow-md sm:rounded-lg px-4 py-4">

--- a/resources/views/patients/edit.blade.php
+++ b/resources/views/patients/edit.blade.php
@@ -1,11 +1,15 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Edit Patient') }}
-        </h2>
+        <div class="flex items-center space-x-2">
+            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 12c2.485 0 4.5-2.015 4.5-4.5S14.485 3 12 3 7.5 5.015 7.5 7.5 9.515 12 12 12zM3 21a9 9 0 0118 0H3z" fill="currentColor"/>
+            </svg>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Edit Patient') }}</h2>
+        </div>
+        <x-breadcrumb current="Edit Patient" />
     </x-slot>
 
-    <div class="py-12">
+    <div class="py-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="relative overflow-x-auto shadow-md sm:rounded-lg px-4 py-4">

--- a/resources/views/patients/history.blade.php
+++ b/resources/views/patients/history.blade.php
@@ -1,11 +1,15 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Patient History') }}
-        </h2>
+        <div class="flex items-center space-x-2">
+            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 12c2.485 0 4.5-2.015 4.5-4.5S14.485 3 12 3 7.5 5.015 7.5 7.5 9.515 12 12 12zM3 21a9 9 0 0118 0H3z" fill="currentColor"/>
+            </svg>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Patient History') }}</h2>
+        </div>
+        <x-breadcrumb current="Patient History" />
     </x-slot>
 
-    <div class="py-12">
+    <div class="py-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="relative overflow-x-auto shadow-md sm:rounded-lg px-4 py-4">

--- a/resources/views/patients/index.blade.php
+++ b/resources/views/patients/index.blade.php
@@ -16,10 +16,7 @@
                     </div>
                     @endcan
                     <div class="m-4">
-                        <form action="{{ route('patient.search') }}" method="GET" class="flex space-x-2">
-                                <input type="search" id="q" name="q" value="{{$searchTerm}}" placeholder="Search by name, code, or phone number" class="w-full rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
-                                <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600">Search</button>
-                        </form>
+                        <livewire:search-form route-name="patient.search" placeholder="Search by name, code, or phone number" />
                     </div>
 
                     <table class="w-full text-sm text-left text-gray-700 bg-white shadow rounded-lg">

--- a/resources/views/patients/index.blade.php
+++ b/resources/views/patients/index.blade.php
@@ -15,8 +15,8 @@
                 <div class="relative overflow-x-auto shadow-md sm:rounded-lg">
 
                     @can('manage patients')
-                    <div class="float-right">
-                        <x-link href="{{ route('patients.create') }}" class="m-4">Add new Patient</x-link>
+                    <div class="float-right m-4 space-x-2">
+                        <x-button type="button" onclick="window.location='{{ route('patients.create') }}'">Add new Patient</x-button>
                     </div>
                     @endcan
                     <div class="m-4">

--- a/resources/views/patients/index.blade.php
+++ b/resources/views/patients/index.blade.php
@@ -1,11 +1,15 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Patients') }}
-        </h2>
+        <div class="flex items-center space-x-2">
+            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 12c2.485 0 4.5-2.015 4.5-4.5S14.485 3 12 3 7.5 5.015 7.5 7.5 9.515 12 12 12zM3 21a9 9 0 0118 0H3z" fill="currentColor"/>
+            </svg>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Patients') }}</h2>
+        </div>
+        <x-breadcrumb current="Patients" />
     </x-slot>
 
-    <div class="py-12">
+    <div class="py-6">
         <div class="max-w-8xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="relative overflow-x-auto shadow-md sm:rounded-lg">

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -1,11 +1,15 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Add New User') }}
-        </h2>
+        <div class="flex items-center space-x-2">
+            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M15 12a3 3 0 10-6 0 3 3 0 006 0zM6 21v-2.25A2.25 2.25 0 018.25 16.5h7.5A2.25 2.25 0 0118 18.75V21" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Add New User') }}</h2>
+        </div>
+        <x-breadcrumb current="Add User" />
     </x-slot>
 
-    <div class="py-12">
+    <div class="py-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="relative overflow-x-auto shadow-md sm:rounded-lg px-4 py-4">

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,11 +1,15 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Edit User') }}
-        </h2>
+        <div class="flex items-center space-x-2">
+            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M15 12a3 3 0 10-6 0 3 3 0 006 0zM6 21v-2.25A2.25 2.25 0 018.25 16.5h7.5A2.25 2.25 0 0118 18.75V21" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Edit User') }}</h2>
+        </div>
+        <x-breadcrumb current="Edit User" />
     </x-slot>
 
-    <div class="py-12">
+    <div class="py-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="relative overflow-x-auto shadow-md sm:rounded-lg px-4 py-4">

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -1,11 +1,15 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Users') }}
-        </h2>
+        <div class="flex items-center space-x-2">
+            <svg class="w-6 h-6 text-blue-600" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M15 12a3 3 0 10-6 0 3 3 0 006 0zM6 21v-2.25A2.25 2.25 0 018.25 16.5h7.5A2.25 2.25 0 0118 18.75V21" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">{{ __('Users') }}</h2>
+        </div>
+        <x-breadcrumb current="Users" />
     </x-slot>
 
-    <div class="py-12">
+    <div class="py-6">
         <div class="max-w-8xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="relative overflow-x-auto shadow-md sm:rounded-lg">

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -16,10 +16,7 @@
                     </div>
                     @endcan
                     <div class="m-4 flex">
-                        <form action="{{ route('users.index') }}" method="GET">
-                            <input type="search" id="q" name="q" value="{{$searchTerm}}" placeholder="Search by name" class="rounded-md shadow-sm border-gray-300 focus:border-indigo-500 focus:ring-indigo-500" required>
-                            <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:bg-blue-600" >Search</button>
-                        </form>
+                        <livewire:search-form route-name="users.index" placeholder="Search by name" />
                     </div>
                     <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">
                         <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">


### PR DESCRIPTION
## Summary
- add Flowbite-based header and footer components
- style sidebar with Flowbite drawer classes
- add generic `SearchForm` Livewire component
- use livewire search in appointments, patients and users lists

## Testing
- `npm install`
- `npm run build`
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_684dc53b09e08327a2765ccc708cbd97